### PR TITLE
Update ignoreUrlParametersMatching example

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-precaching.md
+++ b/src/content/en/tools/workbox/modules/workbox-precaching.md
@@ -148,7 +148,7 @@ workbox.precaching.precacheAndRoute(
     { url: '/index.html', revision: '383676' },
   ],
   {
-    ignoreUrlParametersMatching: /.*/
+    ignoreUrlParametersMatching: [/.*/]
   }
 );
 ```


### PR DESCRIPTION
Update the ignoreUrlParametersMatching example on teh workbox-precaching.md page to correctly identify the parameter as an array of Regex patterns

What's changed, or what was fixed?
- Update example to depict ignoreUrlParametersMatching as an array

**Fixes:** #6277

**CC:** @petele
